### PR TITLE
added missing "author_id" attribute for RawMessageUpdateEvent

### DIFF
--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -154,6 +154,8 @@ class RawMessageUpdateEvent(_RawReprMixin):
         The message ID that got updated.
     channel_id: :class:`int`
         The channel ID where the update took place.
+    author_id: :class:`int`
+        The ID of the user who initiated this action.
 
         .. versionadded:: 1.3
     guild_id: Optional[:class:`int`]
@@ -173,6 +175,7 @@ class RawMessageUpdateEvent(_RawReprMixin):
     def __init__(self, data: MessageUpdateEvent) -> None:
         self.message_id: int = int(data['id'])
         self.channel_id: int = int(data['channel_id'])
+        self.author_id: int = int(data['author']['id'])
         self.data: MessageUpdateEvent = data
         self.cached_message: Optional[Message] = None
 


### PR DESCRIPTION
## Summary

This pull requests adds the "author_id" parameter to the RawMessageUpdateEvent in order to check which user updated the message. This is useful as example if you want to check if the bot itself has edited something.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
